### PR TITLE
Fix README typo, normalizeIdentifiers() bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm install refactor-plugin-common
 
 ```js
 const {refactor} = require('shift-refactor');
-const commonMethods = require('refactor-plugin-common');
+const {commonMethods} = require('refactor-plugin-common');
 
 const src = `/* js source */`;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,6 +17,16 @@ describe('plugin-common', () => {
         parse(`const arst=1; var aiai; function foie($arg0_${second}){const $$${first}=2;$$${first}++};foie();`),
       );
     });
+    it('should not throw an Error on any types of parameters', () => {
+      let ast=parse(`(function (w,x=1,{y},[z]) {})`);
+      const gen=new MemorableIdGenerator(10);
+      const paramNames=[gen.next().value,gen.next().value,gen.next().value,gen.next().value];
+      const $script = refactor(ast, commonMethods);
+      $script.normalizeIdentifiers(10);
+      expect($script.raw()).to.deep.equal(
+        parse(`(function ($arg0_${paramNames[0]},$arg1_${paramNames[1]}=1,{$arg2_${paramNames[2]}},[$arg3_${paramNames[3]}]) {})`),
+      );
+    });
     it('should not change global vars', () => {
       let ast = parse(`(function(){const zzzz=1; console.log(zzzz)})`);
       const gen = new MemorableIdGenerator(10);


### PR DESCRIPTION
This PR fixes #2 by applying the `$argn_` syntax to `BindingIdentifier`s inside of `ObjectBinding`s, `ArrayBinding`s and `BindingWithDefault`s. `n` is based on the argument number of the `ObjectBinding`, etc., so this
```js
(function ({x, y, z}, w) {})
```
would become this.
```js
(function ({$arg0_lackingDude, $arg0_farTeapot, $arg0_mellowMode}, $arg1_eatableSaving) {})
```

It also fixes a typo in the README in which the object destructuring syntax of the `import` statement is omitted.